### PR TITLE
Add sheet name and class name fields

### DIFF
--- a/HDproject/Assets/00_Scripts/EditorTool/WindowsEditor/DT/GoogleDTEditor.cs
+++ b/HDproject/Assets/00_Scripts/EditorTool/WindowsEditor/DT/GoogleDTEditor.cs
@@ -35,7 +35,8 @@ public static class GoogleSheetURLParser
 public class GoogleDTEditor : EditorWindow
 {
     private List<string> sheetURLs = new List<string>();
-    private List<string> sheetNames = new List<string>();
+    private List<string> sheetTabNames = new List<string>();
+    private List<string> classNames = new List<string>();
     private string searchString = "";
     private Vector2 scroll;
 
@@ -47,12 +48,12 @@ public class GoogleDTEditor : EditorWindow
 
     private void OnEnable()
     {
-        GoogleSheetLoader.LoadPrefs(sheetURLs, sheetNames);
+        GoogleSheetLoader.LoadPrefs(sheetURLs, sheetTabNames, classNames);
     }
 
     private void OnDisable()
     {
-        GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+        GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
     }
 
     private void OnGUI()
@@ -64,20 +65,19 @@ public class GoogleDTEditor : EditorWindow
         scroll = EditorGUILayout.BeginScrollView(scroll, GUILayout.Height(250));
         for (int i = 0; i < sheetURLs.Count; i++)
         {
-            EditorGUILayout.BeginHorizontal();
-            // ... UI들 ...
-            bool toDelete = false;
-            if (GUILayout.Button("삭제"))
-            {
-                toDelete = true;
-            }
-            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginVertical("box");
+            sheetURLs[i] = EditorGUILayout.TextField("Sheet URL", sheetURLs[i]);
+            sheetTabNames[i] = EditorGUILayout.TextField("Sheet Name", sheetTabNames[i]);
+            classNames[i] = EditorGUILayout.TextField("Class Name", classNames[i]);
+            bool toDelete = GUILayout.Button("삭제");
+            EditorGUILayout.EndVertical();
 
             if (toDelete)
             {
                 sheetURLs.RemoveAt(i);
-                sheetNames.RemoveAt(i);
-                GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+                sheetTabNames.RemoveAt(i);
+                classNames.RemoveAt(i);
+                GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
                 break;
             }
         }
@@ -86,22 +86,23 @@ public class GoogleDTEditor : EditorWindow
         if (GUILayout.Button("Add Sheet"))
         {
             sheetURLs.Add("");
-            sheetNames.Add("");
-            GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+            sheetTabNames.Add("");
+            classNames.Add("");
+            GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
         }
 
         EditorGUILayout.Space();
 
         if (GUILayout.Button("Generate All Data Classes"))
         {
-            GoogleSheetLoader.GenerateAllData(sheetURLs, sheetNames);
-            GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+            GoogleSheetLoader.GenerateAllData(sheetURLs, sheetTabNames, classNames);
+            GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
         }
 
         if (GUILayout.Button("Update Data"))
         {
-            GoogleSheetLoader.GenerateAllData(sheetURLs, sheetNames);
-            GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+            GoogleSheetLoader.GenerateAllData(sheetURLs, sheetTabNames, classNames);
+            GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
         }
 
         EditorGUILayout.Space();
@@ -109,8 +110,9 @@ public class GoogleDTEditor : EditorWindow
         if (GUILayout.Button("Reset"))
         {
             sheetURLs.Clear();
-            sheetNames.Clear();
-            GoogleSheetLoader.SavePrefs(sheetURLs, sheetNames);
+            sheetTabNames.Clear();
+            classNames.Clear();
+            GoogleSheetLoader.SavePrefs(sheetURLs, sheetTabNames, classNames);
         }
     }
 }

--- a/HDproject/Assets/00_Scripts/EditorTool/WindowsEditor/DT/GoogleSheetLoader.cs
+++ b/HDproject/Assets/00_Scripts/EditorTool/WindowsEditor/DT/GoogleSheetLoader.cs
@@ -10,30 +10,41 @@ using UnityEngine;
 public static class GoogleSheetLoader
 {
     private const string PrefKeyURLs = "GoogleDTEditor_SheetURLs";
-    private const string PrefKeyNames = "GoogleDTEditor_SheetNames";
+    private const string PrefKeySheetNames = "GoogleDTEditor_SheetTabNames";
+    private const string PrefKeyClassNames = "GoogleDTEditor_ClassNames";
 
 
 
     // 에디터Prefs에서 시트 목록 불러오기
-    public static void LoadPrefs(List<string> sheetURLs, List<string> sheetNames)
+    public static void LoadPrefs(List<string> sheetURLs, List<string> sheetTabNames, List<string> classNames)
     {
         sheetURLs.Clear();
-        sheetNames.Clear();
+        sheetTabNames.Clear();
+        classNames.Clear();
+
         string urlStr = EditorPrefs.GetString(PrefKeyURLs, "");
-        string nameStr = EditorPrefs.GetString(PrefKeyNames, "");
+        string tabStr = EditorPrefs.GetString(PrefKeySheetNames, "");
+        string classStr = EditorPrefs.GetString(PrefKeyClassNames, "");
+
         if (!string.IsNullOrEmpty(urlStr))
             sheetURLs.AddRange(urlStr.Split('|'));
-        if (!string.IsNullOrEmpty(nameStr))
-            sheetNames.AddRange(nameStr.Split('|'));
-        while (sheetNames.Count < sheetURLs.Count)
-            sheetNames.Add("");
+        if (!string.IsNullOrEmpty(tabStr))
+            sheetTabNames.AddRange(tabStr.Split('|'));
+        if (!string.IsNullOrEmpty(classStr))
+            classNames.AddRange(classStr.Split('|'));
+
+        while (sheetTabNames.Count < sheetURLs.Count)
+            sheetTabNames.Add("");
+        while (classNames.Count < sheetURLs.Count)
+            classNames.Add("");
     }
 
     // 에디터Prefs에 시트 목록 저장
-    public static void SavePrefs(List<string> sheetURLs, List<string> sheetNames)
+    public static void SavePrefs(List<string> sheetURLs, List<string> sheetTabNames, List<string> classNames)
     {
         EditorPrefs.SetString(PrefKeyURLs, string.Join("|", sheetURLs.ToArray()));
-        EditorPrefs.SetString(PrefKeyNames, string.Join("|", sheetNames.ToArray()));
+        EditorPrefs.SetString(PrefKeySheetNames, string.Join("|", sheetTabNames.ToArray()));
+        EditorPrefs.SetString(PrefKeyClassNames, string.Join("|", classNames.ToArray()));
     }
 
     public static List<List<string>> LoadCSVFromUrl(string csvUrl)
@@ -92,13 +103,13 @@ public static class GoogleSheetLoader
 
 
     // 자동 코드 생성
-    public static void GenerateAllData(List<string> sheetURLs, List<string> sheetNames, string generatedDir = "Assets/Scripts/Generated/")
+    public static void GenerateAllData(List<string> sheetURLs, List<string> sheetTabNames, List<string> classNames, string generatedDir = "Assets/Scripts/Generated/")
     {
         for (int idx = 0; idx < sheetURLs.Count; idx++)
         {
             string url = sheetURLs[idx];
-            string sheetName = sheetNames[idx];
-            if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(sheetName))
+            string className = classNames[idx];
+            if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(className))
                 continue;
 
             string id = GoogleSheetURLParser.ExtractSpreadsheetId(url);
@@ -121,7 +132,7 @@ public static class GoogleSheetLoader
 
                     // 제네릭 코드 생성 호출
                     GenericSheetClassGenerator.Generate(
-                        sheetName.Replace(" ", ""),
+                        className.Replace(" ", ""),
                         headers,
                         types,
                         rows,


### PR DESCRIPTION
## Summary
- extend GoogleSheetLoader with extra prefs for sheet names and class names
- update GoogleDTEditor UI to accept sheet url, sheet name, and class name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b8f7c204832fa6b0979e116cf0f1